### PR TITLE
change graph constructor character

### DIFF
--- a/utils/reply.py
+++ b/utils/reply.py
@@ -29,6 +29,6 @@ def get_reply_edit_time(dt):
 def get_plot(label, value):
     plot = ''
     for l, v in zip(label[::-1], value[::-1]):
-        v = '|' * v
+        v = '▨' * v
         plot = plot + '    {:02d} - {}  \n'.format(l, v)
     return plot


### PR DESCRIPTION
As recommended in [this thread](https://www.reddit.com/r/Games/comments/dwlti8/star_wars_jedi_fallen_order_review_thread/), replaced graph constructor character with ▨ (Unicode 25A8). This is simply a QoL suggestion and not a bug. Best!